### PR TITLE
Fixed error when converting Date object (instead of datestring) to Date

### DIFF
--- a/spec/just-json.spec.ts
+++ b/spec/just-json.spec.ts
@@ -63,12 +63,15 @@ describe('json (without automatic stringify)', function () {
             propNum: number;
             @jsonArrayMember(String)
             propArr: String[];
+            @jsonMember
+            propDate: Date;
         }
 
         const json = Object.freeze({
             propStr: 'dsgs',
             propNum: 653,
             propArr: ['dslfks'],
+            propDate: new Date(1543915254),
         });
 
         it('should deserialize', function () {

--- a/src/typedjson/deserializer.ts
+++ b/src/typedjson/deserializer.ts
@@ -274,6 +274,8 @@ export class Deserializer<T>
 
             if (typeof sourceObject === "string" || (typeof sourceObject === "number" && sourceObject > 0))
                 return new Date(sourceObject as any);
+            else if (sourceObject instanceof Date)
+                return sourceObject
             else
                 this._throwTypeMismatchError("Date", "an ISO-8601 string", srcTypeNameForDebug, memberName);
         }


### PR DESCRIPTION
Hi John

I noticed an error when calling TypedJSON.parse with an object instead of JSON. In my use case, I already have a JS object and use TypedJSON to convert it to an instance of the right class, in a nested fashion.
As my JS object contains Date properties, TypedJSON failed when trying to convert the corresponding properties to Date objects. It expected ISO-8601 strings and not Date objects.
I'm therefore proposing an easy fix for this, by just returning the Date object as is (no conversion needed).

Regards, Simon 