### PR TITLE
Fix bug with timestamp before epoch

### DIFF
--- a/spec/base.spec.ts
+++ b/spec/base.spec.ts
@@ -8,6 +8,7 @@ describe('basic serialization of', () => {
             expect(TypedJSON.parse('45834', Number)).toEqual(45834);
             expect(TypedJSON.parse('true', Boolean)).toEqual(true);
             expect(TypedJSON.parse('1543915254', Date)).toEqual(new Date(1543915254));
+            expect(TypedJSON.parse('-1543915254', Date)).toEqual(new Date(-1543915254));
             expect(TypedJSON.parse('"1970-01-18T20:51:55.254Z"', Date))
                 .toEqual(new Date(1543915254));
 
@@ -23,6 +24,8 @@ describe('basic serialization of', () => {
             expect(TypedJSON.stringify(true, Boolean)).toEqual('true');
             expect(TypedJSON.stringify(new Date(1543915254), Date))
                 .toEqual(`"${new Date(1543915254).toISOString()}"`);
+            expect(TypedJSON.stringify(new Date(-1543915254), Date))
+                .toEqual(`"${new Date(-1543915254).toISOString()}"`);
             expect(TypedJSON.stringify(new Date('2018-12-04T09:20:54'), Date))
                 .toEqual(`"${new Date('2018-12-04T09:20:54').toISOString()}"`);
 

--- a/spec/helpers.spec.ts
+++ b/spec/helpers.spec.ts
@@ -1,0 +1,61 @@
+import {shouldOmitParseString} from '../src/typedjson/helpers';
+
+describe('helpers', () => {
+    describe('shouldOmitParseString', () => {
+        it('should handle plain numbers', () => {
+            expect(shouldOmitParseString('50', Number)).toEqual(false);
+        });
+        it('should handle numbers with decimal places', () => {
+            expect(shouldOmitParseString('50.120', Number)).toEqual(false);
+        });
+        it('should handle negative numbers', () => {
+            expect(shouldOmitParseString('-50', Number)).toEqual(false);
+        });
+        it('should handle negative numbers with decimal places', () => {
+            expect(shouldOmitParseString('-50.120', Number)).toEqual(false);
+        });
+        it('should handle numbers with a plus', () => {
+            expect(shouldOmitParseString('-50', Number)).toEqual(false);
+        });
+        it('should handle negative numbers with a plus and decimal places', () => {
+            expect(shouldOmitParseString('+50.120', Number)).toEqual(false);
+        });
+        it('should handle exponential notation', () => {
+            expect(shouldOmitParseString('1e2', Number)).toEqual(false);
+        });
+        it('should handle exponential notation with decimal places', () => {
+            expect(shouldOmitParseString('1.120e2', Number)).toEqual(false);
+        });
+        it('should handle negative exponential notation', () => {
+            expect(shouldOmitParseString('-1e2', Number)).toEqual(false);
+        });
+        it('should handle negative exponential notation with decimal places', () => {
+            expect(shouldOmitParseString('-1.120e2', Number)).toEqual(false);
+        });
+        it('should handle positive exponential notation', () => {
+            expect(shouldOmitParseString('+1e2', Number)).toEqual(false);
+        });
+        it('should handle positive exponential notation with decimal places', () => {
+            expect(shouldOmitParseString('+1.120e2', Number)).toEqual(false);
+        });
+
+        it('should handle plain numeric dates', () => {
+            expect(shouldOmitParseString('50', Date)).toEqual(false);
+        });
+        it('should handle negative dates', () => {
+            expect(shouldOmitParseString('-50', Date)).toEqual(false);
+        });
+        it('should handle dates with a plus', () => {
+            expect(shouldOmitParseString('-50', Date)).toEqual(false);
+        });
+        it('should handle dates in exponential notation', () => {
+            expect(shouldOmitParseString('1e2', Date)).toEqual(false);
+        });
+        it('should handle dates in negative exponential notation', () => {
+            expect(shouldOmitParseString('-1e2', Date)).toEqual(false);
+        });
+        it('should handle dates in positive exponential notation', () => {
+            expect(shouldOmitParseString('+1e2', Date)).toEqual(false);
+        });
+    });
+});

--- a/src/typedjson/deserializer.ts
+++ b/src/typedjson/deserializer.ts
@@ -613,9 +613,18 @@ function deserializeDate(
     // the Epoch).
     // ISO 8601 spec.: https://www.w3.org/TR/NOTE-datetime
 
-    if (typeof sourceObject === 'string'
-        || (typeof sourceObject === 'number' && sourceObject > 0)) {
-        return new Date(sourceObject as any);
+    if (typeof sourceObject === 'number') {
+        const isInteger = sourceObject % 1 === 0;
+        if (!isInteger) {
+            throw new TypeError(
+                `Could not deserialize ${memberName} as Date:`
+                + ` expected an integer, got a number with decimal places.`,
+            );
+        }
+
+        return new Date(sourceObject);
+    } else if (typeof sourceObject === 'string') {
+        return new Date(sourceObject);
     } else if (sourceObject instanceof Date) {
         return sourceObject;
     } else {

--- a/src/typedjson/helpers.ts
+++ b/src/typedjson/helpers.ts
@@ -48,10 +48,14 @@ export function shouldOmitParseString(jsonStr: string, expectedType: Function): 
     const hasQuotes = jsonStr.length >= 2
         && jsonStr[0] === '"'
         && jsonStr[jsonStr.length - 1] === '"';
-    const isInteger = /^\d+$/.test(jsonStr.trim());
 
-    return (expectsTypesSerializedAsStrings && !hasQuotes)
-        || ((!hasQuotes && !isInteger) && expectedType === Date);
+    if (expectedType === Date) {
+        // Date can both have strings and numbers as input
+        const isNumber = !isNaN(Number(jsonStr.trim()));
+        return !hasQuotes && !isNumber;
+    }
+
+    return expectsTypesSerializedAsStrings && !hasQuotes;
 }
 
 export function parseToJSObject<T>(json: any, expectedType: Serializable<T>): Object {

--- a/src/typedjson/helpers.ts
+++ b/src/typedjson/helpers.ts
@@ -40,7 +40,7 @@ export function isObject(value: any): value is Object {
     return typeof value === 'object';
 }
 
-function shouldOmitParseString(jsonStr: string, expectedType: Function): boolean {
+export function shouldOmitParseString(jsonStr: string, expectedType: Function): boolean {
     const expectsTypesSerializedAsStrings = expectedType === String
         || expectedType === ArrayBuffer
         || expectedType === DataView;


### PR DESCRIPTION
Deserializing a date with a negative timestamp (dates before 1970-01-01) caused rejection due to a combination of bad `isInteger` checking and an unneeded greater than zero check.

I checked and Firefox, Chrome, nor Node seem to have a problem with creating dates from timestamps with decimal places. This means that the `isInteger` check is not necessarily needed. I don't have a preference towards keeping it or not keeping it. 