### PR TITLE
Continuation, throw when type not determined

### DIFF
--- a/spec/errors.spec.ts
+++ b/spec/errors.spec.ts
@@ -1,0 +1,24 @@
+import {jsonMember, jsonObject, TypedJSON} from '../src';
+
+describe('errors', () => {
+    class CustomType {
+    }
+
+    it('should be thrown when types could not be determined', () => {
+        @jsonObject
+        class TestNonDeterminableTypes {
+
+            @jsonMember
+            bar: CustomType;
+        }
+
+        const typedJson = new TypedJSON(TestNonDeterminableTypes);
+        typedJson.config({
+            errorHandler: e => {
+                throw e;
+            },
+        });
+
+        expect(() => typedJson.parse({bar: 'bar'})).toThrow();
+    });
+});

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -121,9 +121,14 @@ export class Deserializer<T> {
         if (typeof sourceObject === 'object') {
             return convertAsObject(sourceObject, typeDescriptor, knownTypes, memberName, this);
         }
-        this.errorHandler(new TypeError(
-            `Could not deserialize '${memberName}': don't know how to deserialize this type'.`,
-        ));
+
+        let error = `Could not deserialize '${memberName}'; don't know how to deserialize type`;
+
+        if (typeDescriptor.hasFriendlyName()) {
+            error += ` '${typeDescriptor.ctor.name}'`;
+        }
+
+        this.errorHandler(new TypeError(`${error}.`));
     }
 
     instantiateType(ctor: any) {

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -155,9 +155,14 @@ export class Serializer {
         if (typeof sourceObject === 'object') {
             return convertAsObject(sourceObject, typeDescriptor, memberName, this, memberOptions);
         }
-        this.errorHandler(new TypeError(
-            `Could not serialize '${memberName}': don't know how to serialize this type'.`,
-        ));
+
+        let error = `Could not serialize '${memberName}'; don't know how to serialize type`;
+
+        if (typeDescriptor.hasFriendlyName()) {
+            error += ` '${typeDescriptor.ctor.name}'`;
+        }
+
+        this.errorHandler(new TypeError(`${error}.`));
     }
 }
 

--- a/src/type-descriptor.ts
+++ b/src/type-descriptor.ts
@@ -5,6 +5,10 @@ export abstract class TypeDescriptor {
     getTypes(): Array<Function> {
         return [this.ctor];
     }
+
+    hasFriendlyName(): boolean {
+        return this.ctor.name !== 'Object';
+    }
 }
 
 export type Typelike = TypeDescriptor | Function;


### PR DESCRIPTION
This should conclude and close #133. The PR continues on your work from `1.6.0-rc2` @Neos3452. It adds a test and includes the name of the type which could not be (de)serialized.

I've tested the prerelease and it works great.