### PR TITLE
Allow debugging tests with run test:inspect

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,7 +22,7 @@ jobs:
         yarn install --frozen-lockfile
         yarn run lint
         yarn run build
-        yarn run test
+        yarn run coverage
         yarn run size
       env:
         CI: true

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -5,7 +5,7 @@ function mapFilenames(filenames) {
 module.exports = {
     '*': () => [
         'tsc -p tsconfig/tsconfig.app.json',
-        'npm run test',
+        'yarn run test',
     ],
     '*.ts': (filenames) => [
         `eslint --fix --cache ${mapFilenames(filenames)}`,

--- a/package.json
+++ b/package.json
@@ -17,10 +17,13 @@
     "build": "run-s build:*",
     "build:clean": "rimraf ./lib",
     "build:ts": "tsc --build ./tsconfig/tsconfig.bundle.*.json",
+    "coverage": "nyc yarn run test",
     "lint": "eslint \"spec/**/*.ts\" \"src/**/*.ts\"",
-    "preversion": "yarn run test",
+    "preversion": "yarn run coverage",
     "size": "size-limit",
-    "test": "nyc ts-node-transpile-only --project tsconfig/tsconfig.spec.json node_modules/jasmine/bin/jasmine.js",
+    "test": "yarn run test:base node_modules/jasmine/bin/jasmine.js",
+    "test:base": "TS_NODE_PROJECT=tsconfig/tsconfig.spec.json node -r ts-node/register",
+    "test:inspect": "yarn run test:base --inspect-brk node_modules/jasmine/bin/jasmine.js",
     "version": "yarn run build"
   },
   "repository": {


### PR DESCRIPTION
I've also split coverage to a separate script as it does not need to run on every test run.