### PR TITLE
Fix handling of TypeDescriptor in @jsonMember

### DIFF
--- a/spec/any.spec.ts
+++ b/spec/any.spec.ts
@@ -1,0 +1,148 @@
+import {AnyT, jsonArrayMember, jsonMember, jsonObject, jsonSetMember, TypedJSON} from '../src';
+
+describe('AnyT', () => {
+    class Foo {
+        constructor(public foo: string) {
+        }
+    }
+
+    describe('on a simple class property', () => {
+        @jsonObject
+        class SimplePropertyAny {
+            @jsonMember(AnyT)
+            any: any;
+
+            @jsonMember(AnyT)
+            anyNullable?: any | null;
+        }
+
+        it('should deserialize simple object correctly', () => {
+            const result = TypedJSON.parse({
+                any: {foo: 'bar'},
+                anyNullable: {foo: 'bar'},
+            }, SimplePropertyAny);
+            expect(result.any).toHaveProperties(['foo']);
+            expect(result.anyNullable).toHaveProperties(['foo']);
+        });
+
+        it('should deserialize class instance correctly', () => {
+            const result = TypedJSON.parse({
+                any: new Foo('bar'),
+                anyNullable: new Foo('bar'),
+            }, SimplePropertyAny);
+            expect(result.any).toBeInstanceOf(Foo);
+            expect(result.any.foo).toEqual('bar');
+            expect(result.anyNullable).toBeInstanceOf(Foo);
+            expect(result.anyNullable.foo).toEqual('bar');
+        });
+    });
+
+    describe('on arrays', () => {
+        @jsonObject
+        class ArrayPropertyAny {
+            @jsonArrayMember(AnyT)
+            any: Array<any>;
+
+            @jsonArrayMember(AnyT)
+            anyNullable?: Array<any> | null;
+        }
+
+        it('should deserialize simple object correctly', () => {
+            const result = TypedJSON.parse({
+                any: [{foo: 'bar'}],
+                anyNullable: [{foo: 'bar'}],
+            }, ArrayPropertyAny);
+            expect(result.any).toBeInstanceOf(Array);
+            expect(result.any[0].foo).toEqual('bar');
+            expect(result.anyNullable).toBeInstanceOf(Array);
+            expect(result.anyNullable[0].foo).toEqual('bar');
+        });
+
+        it('should deserialize class instance correctly', () => {
+            const result = TypedJSON.parse({
+                any: [new Foo('bar')],
+                anyNullable: [new Foo('bar')],
+            }, ArrayPropertyAny);
+            expect(result.any).toBeInstanceOf(Array);
+            expect(result.any[0]).toBeInstanceOf(Foo);
+            expect(result.any[0].foo).toEqual('bar');
+            expect(result.anyNullable).toBeInstanceOf(Array);
+            expect(result.anyNullable[0]).toBeInstanceOf(Foo);
+            expect(result.anyNullable[0].foo).toEqual('bar');
+        });
+    });
+
+    describe('on set', () => {
+        @jsonObject
+        class SetPropertyAny {
+
+            @jsonSetMember(AnyT)
+            any: Set<any>;
+
+            @jsonSetMember(AnyT)
+            anyNullable?: Set<any> | null;
+        }
+
+        it('should deserialize simple object correctly', () => {
+            const foo = {foo: 'bar'};
+            const result = TypedJSON.parse({
+                any: [foo, foo],
+                anyNullable: [foo, foo],
+            }, SetPropertyAny);
+            expect(result.any).toBeInstanceOf(Set);
+            expect(result.any.size).toBe(1);
+            expect(result.any.values().next().value.foo).toEqual('bar');
+            expect(result.anyNullable).toBeInstanceOf(Set);
+            expect(result.anyNullable.size).toBe(1);
+            expect(result.anyNullable.values().next().value.foo).toEqual('bar');
+        });
+
+        it('should deserialize class instance correctly', () => {
+            const foo = new Foo('bar');
+            const result = TypedJSON.parse({
+                any: [foo, foo],
+                anyNullable: [foo, foo],
+            }, SetPropertyAny);
+            expect(result.any).toBeInstanceOf(Set);
+            const firstValueAny = result.any.values().next().value;
+            expect(firstValueAny).toBeInstanceOf(Foo);
+            expect(firstValueAny.foo).toEqual('bar');
+            expect(result.anyNullable).toBeInstanceOf(Set);
+            const firstValueAnyNullable = result.anyNullable.values().next().value;
+            expect(firstValueAnyNullable).toBeInstanceOf(Foo);
+            expect(firstValueAnyNullable.foo).toEqual('bar');
+        });
+    });
+
+    it('should handle complex structures', () => {
+        @jsonObject
+        class Event {
+
+            @jsonMember(AnyT)
+            data?: {[k: string]: any} | null;
+        }
+
+        @jsonObject
+        class A {
+
+            @jsonArrayMember(Event)
+            events: Array<Event>
+        }
+
+        const result = TypedJSON.parse({
+            events: [
+                {
+                    data: {
+                        files: [
+                            {
+                                name: 'file1',
+                            },
+                        ],
+                    },
+                },
+            ],
+        }, A);
+
+        expect(result.events[0].data.files[0].name).toEqual('file1');
+    });
+});

--- a/spec/any.spec.ts
+++ b/spec/any.spec.ts
@@ -1,11 +1,6 @@
 import {AnyT, jsonArrayMember, jsonMember, jsonObject, jsonSetMember, TypedJSON} from '../src';
 
 describe('AnyT', () => {
-    class Foo {
-        constructor(public foo: string) {
-        }
-    }
-
     describe('on a simple class property', () => {
         @jsonObject
         class SimplePropertyAny {
@@ -26,7 +21,7 @@ describe('AnyT', () => {
         });
 
         it('should deserialize class instance correctly', () => {
-            const foo = new Foo('bar');
+            const foo = {foo: 'bar'};
             const result = TypedJSON.parse({
                 any: foo,
                 anyNullable: foo,
@@ -36,7 +31,7 @@ describe('AnyT', () => {
         });
 
         it('should serialize class instances correctly', () => {
-            const foo = new Foo('bar');
+            const foo = {foo: 'bar'};
             const simplePropertyAny = new SimplePropertyAny();
             simplePropertyAny.any = foo;
             simplePropertyAny.anyNullable = foo;
@@ -68,7 +63,7 @@ describe('AnyT', () => {
         });
 
         it('should deserialize class instance correctly', () => {
-            const foo = new Foo('bar');
+            const foo = {foo: 'bar'};
             const result = TypedJSON.parse({
                 any: [foo],
                 anyNullable: [foo],
@@ -80,7 +75,7 @@ describe('AnyT', () => {
         });
 
         it('should serialize class instances correctly', () => {
-            const foo = new Foo('bar');
+            const foo = {foo: 'bar'};
             const arrayPropertyAny = new ArrayPropertyAny();
             arrayPropertyAny.any = [foo];
             arrayPropertyAny.anyNullable = [foo];
@@ -116,7 +111,7 @@ describe('AnyT', () => {
         });
 
         it('should deserialize class instance correctly', () => {
-            const foo = new Foo('bar');
+            const foo = {foo: 'bar'};
             const result = TypedJSON.parse({
                 any: [foo, foo],
                 anyNullable: [foo, foo],
@@ -128,7 +123,7 @@ describe('AnyT', () => {
         });
 
         it('should serialize class instances correctly', () => {
-            const foo = new Foo('bar');
+            const foo = {foo: 'bar'};
             const setPropertyAny = new SetPropertyAny();
             setPropertyAny.any = new Set([foo, foo]);
             setPropertyAny.anyNullable = new Set([foo, foo]);

--- a/spec/any.spec.ts
+++ b/spec/any.spec.ts
@@ -34,6 +34,16 @@ describe('AnyT', () => {
             expect(result.any).toEqual(foo);
             expect(result.anyNullable).toEqual(foo);
         });
+
+        it('should serialize class instances correctly', () => {
+            const foo = new Foo('bar');
+            const simplePropertyAny = new SimplePropertyAny();
+            simplePropertyAny.any = foo;
+            simplePropertyAny.anyNullable = foo;
+            const result: any = TypedJSON.toPlainJson(simplePropertyAny, SimplePropertyAny);
+            expect(result.any).toEqual(foo);
+            expect(result.anyNullable).toEqual(foo);
+        });
     });
 
     describe('on arrays', () => {
@@ -66,6 +76,16 @@ describe('AnyT', () => {
             expect(result.any).toBeInstanceOf(Array);
             expect(result.any[0]).toEqual(foo);
             expect(result.anyNullable).toBeInstanceOf(Array);
+            expect(result.anyNullable[0]).toEqual(foo);
+        });
+
+        it('should serialize class instances correctly', () => {
+            const foo = new Foo('bar');
+            const arrayPropertyAny = new ArrayPropertyAny();
+            arrayPropertyAny.any = [foo];
+            arrayPropertyAny.anyNullable = [foo];
+            const result: any = TypedJSON.toPlainJson(arrayPropertyAny, ArrayPropertyAny);
+            expect(result.any[0]).toEqual(foo);
             expect(result.anyNullable[0]).toEqual(foo);
         });
     });
@@ -105,6 +125,16 @@ describe('AnyT', () => {
             expect(result.any.values().next().value).toBe(foo);
             expect(result.anyNullable).toBeInstanceOf(Set);
             expect(result.anyNullable.values().next().value).toBe(foo);
+        });
+
+        it('should serialize class instances correctly', () => {
+            const foo = new Foo('bar');
+            const setPropertyAny = new SetPropertyAny();
+            setPropertyAny.any = new Set([foo, foo]);
+            setPropertyAny.anyNullable = new Set([foo, foo]);
+            const result: any = TypedJSON.toPlainJson(setPropertyAny, SetPropertyAny);
+            expect(result.any.values().next().value).toEqual(foo);
+            expect(result.anyNullable.values().next().value).toEqual(foo);
         });
     });
 

--- a/spec/any.spec.ts
+++ b/spec/any.spec.ts
@@ -30,7 +30,7 @@ describe('AnyT', () => {
             expect(result.anyNullable).toEqual(foo);
         });
 
-        it('should serialize class instances correctly', () => {
+        it('should serialize with referential equality', () => {
             const foo = {foo: 'bar'};
             const simplePropertyAny = new SimplePropertyAny();
             simplePropertyAny.any = foo;
@@ -74,7 +74,7 @@ describe('AnyT', () => {
             expect(result.anyNullable[0]).toEqual(foo);
         });
 
-        it('should serialize class instances correctly', () => {
+        it('should serialize with referential equality', () => {
             const foo = {foo: 'bar'};
             const arrayPropertyAny = new ArrayPropertyAny();
             arrayPropertyAny.any = [foo];
@@ -110,7 +110,7 @@ describe('AnyT', () => {
             expect(result.anyNullable.values().next().value).toEqual(foo);
         });
 
-        it('should deserialize class instance correctly', () => {
+        it('should deserialize with referential equality', () => {
             const foo = {foo: 'bar'};
             const result = TypedJSON.parse({
                 any: [foo, foo],
@@ -122,7 +122,7 @@ describe('AnyT', () => {
             expect(result.anyNullable.values().next().value).toBe(foo);
         });
 
-        it('should serialize class instances correctly', () => {
+        it('should serialize with referential equality', () => {
             const foo = {foo: 'bar'};
             const setPropertyAny = new SetPropertyAny();
             setPropertyAny.any = new Set([foo, foo]);

--- a/spec/any.spec.ts
+++ b/spec/any.spec.ts
@@ -26,14 +26,13 @@ describe('AnyT', () => {
         });
 
         it('should deserialize class instance correctly', () => {
+            const foo = new Foo('bar');
             const result = TypedJSON.parse({
-                any: new Foo('bar'),
-                anyNullable: new Foo('bar'),
+                any: foo,
+                anyNullable: foo,
             }, SimplePropertyAny);
-            expect(result.any).toBeInstanceOf(Foo);
-            expect(result.any.foo).toEqual('bar');
-            expect(result.anyNullable).toBeInstanceOf(Foo);
-            expect(result.anyNullable.foo).toEqual('bar');
+            expect(result.any).toEqual(foo);
+            expect(result.anyNullable).toEqual(foo);
         });
     });
 
@@ -59,16 +58,15 @@ describe('AnyT', () => {
         });
 
         it('should deserialize class instance correctly', () => {
+            const foo = new Foo('bar');
             const result = TypedJSON.parse({
-                any: [new Foo('bar')],
-                anyNullable: [new Foo('bar')],
+                any: [foo],
+                anyNullable: [foo],
             }, ArrayPropertyAny);
             expect(result.any).toBeInstanceOf(Array);
-            expect(result.any[0]).toBeInstanceOf(Foo);
-            expect(result.any[0].foo).toEqual('bar');
+            expect(result.any[0]).toEqual(foo);
             expect(result.anyNullable).toBeInstanceOf(Array);
-            expect(result.anyNullable[0]).toBeInstanceOf(Foo);
-            expect(result.anyNullable[0].foo).toEqual('bar');
+            expect(result.anyNullable[0]).toEqual(foo);
         });
     });
 
@@ -91,10 +89,10 @@ describe('AnyT', () => {
             }, SetPropertyAny);
             expect(result.any).toBeInstanceOf(Set);
             expect(result.any.size).toBe(1);
-            expect(result.any.values().next().value.foo).toEqual('bar');
+            expect(result.any.values().next().value).toEqual(foo);
             expect(result.anyNullable).toBeInstanceOf(Set);
             expect(result.anyNullable.size).toBe(1);
-            expect(result.anyNullable.values().next().value.foo).toEqual('bar');
+            expect(result.anyNullable.values().next().value).toEqual(foo);
         });
 
         it('should deserialize class instance correctly', () => {
@@ -104,13 +102,9 @@ describe('AnyT', () => {
                 anyNullable: [foo, foo],
             }, SetPropertyAny);
             expect(result.any).toBeInstanceOf(Set);
-            const firstValueAny = result.any.values().next().value;
-            expect(firstValueAny).toBeInstanceOf(Foo);
-            expect(firstValueAny.foo).toEqual('bar');
+            expect(result.any.values().next().value).toBe(foo);
             expect(result.anyNullable).toBeInstanceOf(Set);
-            const firstValueAnyNullable = result.anyNullable.values().next().value;
-            expect(firstValueAnyNullable).toBeInstanceOf(Foo);
-            expect(firstValueAnyNullable.foo).toEqual('bar');
+            expect(result.anyNullable.values().next().value).toBe(foo);
         });
     });
 

--- a/src/json-array-member.ts
+++ b/src/json-array-member.ts
@@ -5,9 +5,10 @@ import {
     ArrayTypeDescriptor,
     ensureTypeDescriptor,
     ensureTypeThunk,
+    MaybeTypeThunk,
     TypeDescriptor,
+    TypeThunk,
 } from './type-descriptor';
-import {MaybeTypeThunk, TypeThunk} from './types';
 
 declare abstract class Reflect {
     static getMetadata(metadataKey: string, target: any, targetKey: string | symbol): any;

--- a/src/json-map-member.ts
+++ b/src/json-map-member.ts
@@ -1,8 +1,7 @@
 import {isReflectMetadataSupported, logError, MISSING_REFLECT_CONF_MSG, nameof} from './helpers';
 import {injectMetadataInformation} from './metadata';
 import {extractOptionBase, OptionsBase} from './options-base';
-import {ensureTypeThunk, MapOptions, MapT} from './type-descriptor';
-import {MaybeTypeThunk} from './types';
+import {ensureTypeThunk, MapOptions, MapT, MaybeTypeThunk} from './type-descriptor';
 
 declare abstract class Reflect {
     static getMetadata(metadataKey: string, target: any, targetKey: string | symbol): any;

--- a/src/json-member.ts
+++ b/src/json-member.ts
@@ -173,7 +173,7 @@ runtime. ${LAZY_TYPE_EXPLANATION}`);
             ) as Function | null | undefined;
 
             if (reflectCtor == null) {
-                logError(`${decoratorName}: cannot resolve detected property constructor at\
+                logError(`${decoratorName}: cannot resolve detected property constructor at \
 runtime. ${LAZY_TYPE_EXPLANATION}`);
                 return;
             }

--- a/src/json-member.ts
+++ b/src/json-member.ts
@@ -18,6 +18,7 @@ import {
     MaybeTypeThunk,
     SetTypeDescriptor,
     TypeDescriptor,
+    Typelike,
     TypeThunk,
 } from './type-descriptor';
 import {Constructor, IndexedObject} from './types';
@@ -31,7 +32,7 @@ export interface IJsonMemberOptions extends OptionsBase {
      * Sets the constructor of the property.
      * Optional with ReflectDecorators.
      */
-    constructor?: Function | TypeDescriptor | null;
+    constructor?: Typelike | null;
 
     /** When set, indicates that the member must be present when deserializing. */
     isRequired?: boolean | null;
@@ -206,11 +207,11 @@ runtime. ${LAZY_TYPE_EXPLANATION}`);
     };
 }
 
-function isConstructorEqual(type: TypeDescriptor | Function, constructor: Constructor<any>) {
+function isConstructorEqual(type: Typelike, constructor: Constructor<any>) {
     return type instanceof TypeDescriptor ? type.ctor === constructor : type === constructor;
 }
 
-function isSpecialPropertyType(decoratorName: string, typeDescriptor: TypeDescriptor | Function) {
+function isSpecialPropertyType(decoratorName: string, typeDescriptor: Typelike) {
     if (!(typeDescriptor instanceof ArrayTypeDescriptor)
         && isConstructorEqual(typeDescriptor, Array)) {
         logError(`${decoratorName}: property is an Array. Use the jsonArrayMember decorator to`

--- a/src/json-member.ts
+++ b/src/json-member.ts
@@ -14,6 +14,8 @@ import {
     ArrayTypeDescriptor,
     ensureTypeDescriptor,
     ensureTypeThunk,
+    isTypelike,
+    isTypeThunk,
     MapTypeDescriptor,
     MaybeTypeThunk,
     SetTypeDescriptor,
@@ -132,7 +134,7 @@ function jsonMemberDecoratorFactory(
         const decoratorName = `@jsonMember on ${nameof(target.constructor)}.${String(property)}`;
         let typeThunk: TypeThunk | undefined;
 
-        if (typeof optionsOrType === 'function' || optionsOrType instanceof TypeDescriptor) {
+        if (isTypelike(optionsOrType) || isTypeThunk(optionsOrType)) {
             typeThunk = ensureTypeThunk(optionsOrType, decoratorName);
         } else {
             options = optionsOrType;

--- a/src/json-member.ts
+++ b/src/json-member.ts
@@ -15,10 +15,12 @@ import {
     ensureTypeDescriptor,
     ensureTypeThunk,
     MapTypeDescriptor,
+    MaybeTypeThunk,
     SetTypeDescriptor,
     TypeDescriptor,
+    TypeThunk,
 } from './type-descriptor';
-import {Constructor, IndexedObject, MaybeTypeThunk, TypeThunk} from './types';
+import {Constructor, IndexedObject} from './types';
 
 declare abstract class Reflect {
     static getMetadata(metadataKey: string, target: any, targetKey: string | symbol): any;

--- a/src/json-set-member.ts
+++ b/src/json-set-member.ts
@@ -1,8 +1,7 @@
 import {isReflectMetadataSupported, logError, MISSING_REFLECT_CONF_MSG, nameof} from './helpers';
 import {injectMetadataInformation} from './metadata';
 import {extractOptionBase, OptionsBase} from './options-base';
-import {ensureTypeThunk, SetT} from './type-descriptor';
-import {MaybeTypeThunk} from './types';
+import {ensureTypeThunk, MaybeTypeThunk, SetT} from './type-descriptor';
 
 declare abstract class Reflect {
     static getMetadata(metadataKey: string, target: any, targetKey: string | symbol): any;

--- a/src/type-descriptor.ts
+++ b/src/type-descriptor.ts
@@ -1,5 +1,6 @@
 import {LAZY_TYPE_EXPLANATION} from './helpers';
-import {MaybeTypeThunk, TypeThunk} from './types';
+import {IJsonMemberOptions} from './json-member';
+import {IndexedObject, MaybeTypeThunk, TypeThunk} from './types';
 
 export abstract class TypeDescriptor {
     protected constructor(readonly ctor: Function) {
@@ -151,4 +152,13 @@ export function ensureTypeThunk(
     }
 
     return typeThunkOrSerializable as TypeThunk;
+}
+
+/**
+ * Checks if the given value is a `MaybeTypeThunk`.
+ */
+export function isMaybeTypeThunk(
+    type: IndexedObject | IJsonMemberOptions | MaybeTypeThunk | undefined | null,
+): type is MaybeTypeThunk {
+    return type === 'function' || type instanceof TypeDescriptor;
 }

--- a/src/type-descriptor.ts
+++ b/src/type-descriptor.ts
@@ -1,5 +1,5 @@
 import {LAZY_TYPE_EXPLANATION} from './helpers';
-import {MaybeTypeThunk, TypeThunk} from './types';
+import {Serializable} from './types';
 
 export abstract class TypeDescriptor {
     protected constructor(readonly ctor: Function) {
@@ -124,6 +124,9 @@ export const AnyT = new ConcreteTypeDescriptor(() => undefined);
 // export function DictT(elementType: Typelike): DictionaryTypeDescriptor {
 //     return new DictionaryTypeDescriptor(ensureTypeDescriptor(elementType));
 // }
+
+export type TypeThunk = () => Serializable<any> | TypeDescriptor;
+export type MaybeTypeThunk = Serializable<any> | TypeDescriptor | TypeThunk;
 
 export function isTypelike(type: any): type is Typelike {
     return type != null && (typeof type === 'function' || type instanceof TypeDescriptor);

--- a/src/type-descriptor.ts
+++ b/src/type-descriptor.ts
@@ -1,6 +1,5 @@
 import {LAZY_TYPE_EXPLANATION} from './helpers';
-import {IJsonMemberOptions} from './json-member';
-import {IndexedObject, MaybeTypeThunk, TypeThunk} from './types';
+import {MaybeTypeThunk, TypeThunk} from './types';
 
 export abstract class TypeDescriptor {
     protected constructor(readonly ctor: Function) {

--- a/src/type-descriptor.ts
+++ b/src/type-descriptor.ts
@@ -132,6 +132,10 @@ export function isTypelike(type: any): type is Typelike {
     return type != null && (typeof type === 'function' || type instanceof TypeDescriptor);
 }
 
+export function isTypeThunk(candidate: any): candidate is TypeThunk {
+    return typeof candidate === 'function' && candidate.name === '';
+}
+
 export function ensureTypeDescriptor(type: Typelike): TypeDescriptor {
     return type instanceof TypeDescriptor ? type : new ConcreteTypeDescriptor(type);
 }
@@ -144,14 +148,9 @@ export function ensureTypeThunk(
         throw new Error(`No type given on ${decoratorName}. ${LAZY_TYPE_EXPLANATION}`);
     }
 
-    if (typeThunkOrSerializable instanceof TypeDescriptor) {
-        return () => typeThunkOrSerializable;
+    if (isTypeThunk(typeThunkOrSerializable)) {
+        return typeThunkOrSerializable;
     }
 
-    if (typeThunkOrSerializable.name !== '') {
-        // Function is not anonymous and as such should not be a thunk
-        return () => typeThunkOrSerializable;
-    }
-
-    return typeThunkOrSerializable as TypeThunk;
+    return () => typeThunkOrSerializable;
 }

--- a/src/type-descriptor.ts
+++ b/src/type-descriptor.ts
@@ -153,12 +153,3 @@ export function ensureTypeThunk(
 
     return typeThunkOrSerializable as TypeThunk;
 }
-
-/**
- * Checks if the given value is a `MaybeTypeThunk`.
- */
-export function isMaybeTypeThunk(
-    type: IndexedObject | IJsonMemberOptions | MaybeTypeThunk | undefined | null,
-): type is MaybeTypeThunk {
-    return type === 'function' || type instanceof TypeDescriptor;
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,4 @@
-import {TypeDescriptor} from './type-descriptor';
-
 export type IndexedObject = Object & {[key: string]: any};
-
-export type TypeThunk = () => Serializable<any> | TypeDescriptor;
-export type MaybeTypeThunk = Serializable<any> | TypeDescriptor | TypeThunk;
 
 export interface AbstractType<T> extends Function {
     prototype: T;


### PR DESCRIPTION
Passing a `TypeDescriptor` to `@jsonMember` was broken. A bug introduced due to added complexity of the backwards compatible lazy types.

The PR also adds more thorough testing of `AnyT`. The _should handle complex structures_ test is an example of a failing test due to the `TypeDescriptor` bug.

While the 2nd commits fixes the bug, I extracted some code in the 3rd commit to reduce the complexity of the `jsonMember` function. It results in less types to check and eliminates casting. This change would have found the bug fixed in this PR and will avoid further bugs of this type.