### PR TITLE
Fix reflected type check for Array/Set/Map

### DIFF
--- a/src/json-array-member.ts
+++ b/src/json-array-member.ts
@@ -60,8 +60,11 @@ export function jsonArrayMember(
 
         // If ReflectDecorators is available, use it to check whether 'jsonArrayMember' has been
         // used on an array.
-        if (isReflectMetadataSupported
-            && Reflect.getMetadata('design:type', target, propKey) !== Array) {
+        const reflectedType = isReflectMetadataSupported
+            ? Reflect.getMetadata('design:type', target, propKey)
+            : null;
+
+        if (reflectedType != null && reflectedType !== Array && reflectedType !== Object) {
             logError(`${decoratorName}: property is not an Array. ${MISSING_REFLECT_CONF_MSG}`);
             return;
         }

--- a/src/json-map-member.ts
+++ b/src/json-map-member.ts
@@ -47,8 +47,11 @@ export function jsonMapMember(
 
         // If ReflectDecorators is available, use it to check whether 'jsonMapMember' has been used
         // on a map. Warn if not.
-        if (isReflectMetadataSupported
-            && Reflect.getMetadata('design:type', target, propKey) !== Map) {
+        const reflectedType = isReflectMetadataSupported
+            ? Reflect.getMetadata('design:type', target, propKey)
+            : null;
+
+        if (reflectedType != null && reflectedType !== Map && reflectedType !== Object) {
             logError(`${decoratorName}: property is not a Map. ${MISSING_REFLECT_CONF_MSG}`);
             return;
         }

--- a/src/json-set-member.ts
+++ b/src/json-set-member.ts
@@ -42,8 +42,11 @@ export function jsonSetMember(maybeTypeThunk: MaybeTypeThunk, options: IJsonSetM
 
         // If ReflectDecorators is available, use it to check whether 'jsonSetMember' has been used
         // on a set. Warn if not.
-        if (isReflectMetadataSupported
-            && Reflect.getMetadata('design:type', target, propKey) !== Set) {
+        const reflectedType = isReflectMetadataSupported
+            ? Reflect.getMetadata('design:type', target, propKey)
+            : null;
+
+        if (reflectedType != null && reflectedType !== Set && reflectedType !== Object) {
             logError(`${decoratorName}: property is not a Set. ${MISSING_REFLECT_CONF_MSG}`);
             return;
         }


### PR DESCRIPTION
Fixes #167.

The type check could not deal with complex types such as `Array<string> | null`. This example is only a problem with `strictNullChecks` enabled.