### PR TITLE
Replace usages of prototype builtins

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -73,4 +73,3 @@ overrides:
           functions: false
           variables: true
           typedefs: true
-      no-prototype-builtins: off # @todo check if this should remain off

--- a/src/json-member.ts
+++ b/src/json-member.ts
@@ -142,7 +142,7 @@ function jsonMemberDecoratorFactory(
 
         options = options ?? {};
 
-        if (options.hasOwnProperty('constructor')) {
+        if (Object.prototype.hasOwnProperty.call(options, 'constructor')) {
             if (typeThunk !== undefined) {
                 throw new Error(
                     'Cannot both define constructor option and type. Only one allowed.',

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -108,7 +108,7 @@ export class JsonObjectMetadata {
         }
 
         let metadata: JsonObjectMetadata | undefined;
-        if (prototype.hasOwnProperty(METADATA_FIELD_KEY) === true) {
+        if (Object.prototype.hasOwnProperty.call(prototype, METADATA_FIELD_KEY)) {
             // The class prototype contains own jsonObject metadata
             metadata = prototype[METADATA_FIELD_KEY];
         }
@@ -128,7 +128,7 @@ export class JsonObjectMetadata {
     }
 
     static ensurePresentInPrototype(prototype: IndexedObject): JsonObjectMetadata {
-        if (prototype.hasOwnProperty(METADATA_FIELD_KEY)) {
+        if (Object.prototype.hasOwnProperty.call(prototype, METADATA_FIELD_KEY)) {
             return prototype[METADATA_FIELD_KEY];
         }
         // Target has no JsonObjectMetadata associated with it yet, create it now.


### PR DESCRIPTION
This should improve safety as explained in <https://eslint.org/docs/rules/no-prototype-builtins>.

> … objects can have properties that shadow the builtins on Object.prototype, potentially causing unintended behavior or denial-of-service security vulnerabilities. For example, it would be unsafe for a webserver to parse JSON input from a client and call `hasOwnProperty` directly on the resulting object, because a malicious client could send a JSON value like `{"hasOwnProperty": 1}` and cause the server to crash.

> `Object.create(null)` is a common pattern used to create objects that will be used as a Map. This can lead to errors when it is assumed that objects will have properties from `Object.prototype`

Closes #141.